### PR TITLE
chore: add meson support to build extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ The validator will request permission `<resource_name>#<scope>` (e.g., `appdb#ap
 
 ## Build Instructions
 
+### Local
+
+To compile the extension is required [meson](https://mesonbuild.com/) tool.
+
+```bash
+meson setup build
+meson compile -C build
+```
+The extension will be located inside the `build/` directory, that was
+created during the setup process.
+
 ### Docker
 
 ```bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,12 +5,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-    build-essential libcurl4-openssl-dev postgresql-server-dev-18; \
-    apt-get clean; \
-    rm -rf /var/lib/apt/lists/*
+    build-essential \
+    meson \
+    libcurl4-openssl-dev \
+    postgresql-server-dev-18; \
 WORKDIR /work
-COPY src/ ./src/
-RUN make -C src
+COPY . .
+RUN meson setup build && meson build -C build/
 
 FROM ghcr.io/cloudnative-pg/postgresql:18-standard-trixie
 ARG DEBIAN_FRONTEND=noninteractive
@@ -25,4 +26,4 @@ COPY --chmod=0644 docker/certs/server.crt /usr/local/share/ca-certificates/kc-ro
 RUN update-ca-certificates
 ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 USER postgres
-COPY --from=builder /work/src/kc_validator.so /usr/lib/postgresql/18/lib/
+COPY --from=builder /work/build/kc_validator.so /usr/lib/postgresql/18/lib/

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,24 @@
+project(
+    'postgres-keycloak-oauth-validator', 'c',
+    license: 'Apache-2.0',
+    license_files: 'LICENSE',
+    version: '0.0.1')
+
+# pg_config command is required to get the include directory for
+# the headers
+pg_config = find_program('pg_config')
+includedir_server = run_command(pg_config, '--includedir-server', check: true).stdout().strip()
+
+# PostgreSQL required for standard build (this may not be needed)
+postgres = dependency('libpq')
+# libcurl is required for the oauth calls
+libcurl = dependency('libcurl')
+
+# The library is built as a shared object since it's going to be
+# loaded into PostgreSQL later as an extension.
+# Setting the prefix to '' helps to not habe a `lib` prefix on the
+# final file created
+shared_module('kc_validator', 'src/kc_validator.c',
+              dependencies: [postgres, libcurl],
+              include_directories: [includedir_server],
+              name_prefix: '')

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,9 +1,0 @@
-# Makefile for kc_validator (server module via PGXS)
-MODULE_big = kc_validator
-OBJS = kc_validator.o
-PG_CONFIG = pg_config
-
-SHLIB_LINK += -lcurl
-
-PGXS := $(shell $(PG_CONFIG) --pgxs)
-include $(PGXS)


### PR DESCRIPTION
Since meson is the PostgreSQL standard now to build, we add support for meson and make it the tool required to build.

Closes #8 