### PR TITLE
chore: improve Dockerfile to build as extension image

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,18 @@ created during the setup process.
 
 ### Docker
 
+A simple possibility is to build the image using a plain docker build
+command:
+
 ```bash
 docker build -t pg-kc-validator -f docker/Dockerfile .
+```
+
+To have all the possible labels, annotations, SBOMS, etc. the
+image can be built using Docker Bake:
+
+```bash
+docker buildx bake
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -35,10 +35,16 @@ kind: Cluster
 metadata:
   name: pg-oauth
 spec:
-  imageName: pg18-kc-validator:18.0      # Image containing kc_validator.so
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
   instances: 1
 
   postgresql:
+    extensions:
+      - name: keycloak-oauth-validator
+        ld_library_path:
+          - system
+        image:
+          reference: ghcr.io/cloudnative-pg/postgres-keycloak-oauth-validator-testing:18-dev-trixie
     parameters:
       oauth_validator_libraries: "kc_validator"
       kc.token_endpoint: "https://<keycloak>/realms/<realm>/protocol/openid-connect/token"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,137 @@
+#
+# Copyright © contributors to CloudNativePG, established as
+# CloudNativePG a Series of LF Projects, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+variable "environment" {
+  default = "testing"
+  validation {
+    condition = contains(["testing", "production"], environment)
+    error_message = "environment must be either testing or production"
+  }
+}
+
+variable "registry" {
+  default = "localhost:5000"
+}
+
+variable "insecure" {
+  default = "false"
+}
+
+variable "latest" {
+  default = "false"
+}
+
+variable "tag" {
+  default = "dev"
+}
+
+variable "buildVersion" {
+  default = "dev"
+}
+
+variable "revision" {
+  default = ""
+}
+
+suffix = (environment == "testing") ? "-testing" : ""
+
+title = "PostgreSQL Keycloak Validator Extension"
+description = ""
+authors = "The CloudNativePG Contributors"
+url = "https://github.com/cloudnative-pg/"
+documentation = "https://cloudnative-pg.io/"
+license = "Apache-2.0"
+now = timestamp()
+
+
+# renovate: datasource=docker
+baseImage = "ghcr.io/cloudnative-pg/postgresql:18-standard-trixie"
+
+target "default" {
+  matrix = {
+    distro = [
+      "base",
+    ]
+  }
+
+  name = "${distro}"
+  platforms = ["linux/amd64", "linux/arm64"]
+  tags = [
+    "${registry}/postgres-keycloak-oauth-validator${suffix}:${tag}",
+    latest("${registry}/postgres-keycloak-oauth-validator${suffix}", "${latest}"),
+  ]
+
+  dockerfile = "docker/Dockerfile"
+  context    = "."
+
+  args = {
+    BASE = "${baseImage}"
+  }
+
+  output = [
+    "type=image,registry.insecure=${insecure}",
+  ]
+
+  attest = [
+    "type=provenance,mode=max",
+    "type=sbom"
+  ]
+  annotations = [
+    "index,manifest:org.opencontainers.image.created=${now}",
+    "index,manifest:org.opencontainers.image.url=${url}",
+    "index,manifest:org.opencontainers.image.source=${url}",
+    "index,manifest:org.opencontainers.image.version=${buildVersion}",
+    "index,manifest:org.opencontainers.image.revision=${revision}",
+    "index,manifest:org.opencontainers.image.vendor=${authors}",
+    "index,manifest:org.opencontainers.image.title=${title}",
+    "index,manifest:org.opencontainers.image.description=${description}",
+    "index,manifest:org.opencontainers.image.documentation=${documentation}",
+    "index,manifest:org.opencontainers.image.authors=${authors}",
+    "index,manifest:org.opencontainers.image.licenses=${license}",
+    "index,manifest:org.opencontainers.image.base.name=",
+    "index,manifest:org.opencontainers.image.base.digest=",
+  ]
+  labels = {
+    "org.opencontainers.image.created"       = "${now}",
+    "org.opencontainers.image.url"           = "${url}",
+    "org.opencontainers.image.source"        = "${url}",
+    "org.opencontainers.image.version"       = "${buildVersion}",
+    "org.opencontainers.image.revision"      = "${revision}",
+    "org.opencontainers.image.vendor"        = "${authors}",
+    "org.opencontainers.image.title"         = "${title}",
+    "org.opencontainers.image.description"   = "${description}",
+    "org.opencontainers.image.documentation" = "${documentation}",
+    "org.opencontainers.image.authors"       = "${authors}",
+    "org.opencontainers.image.licenses"      = "${license}",
+    "org.opencontainers.image.base.name"     = "",
+    "org.opencontainers.image.base.digest"   = "",
+    "name"                                   = "${title}",
+    "maintainer"                             = "${authors}",
+    "vendor"                                 = "${authors}",
+    "version"                                = "${buildVersion}",
+    "release"                                = "1",
+    "description"                            = "${description}",
+    "summary"                                = "${description}",
+  }
+}
+
+function latest {
+  params = [ image, latest ]
+  result = (latest == "true") ? "${image}:latest" : ""
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -51,8 +51,8 @@ variable "revision" {
 
 suffix = (environment == "testing") ? "-testing" : ""
 
-title = "PostgreSQL Keycloak Validator Extension"
-description = ""
+title = "PostgreSQL OAuth validator module for Keycloak"
+description = "This module enables PostgreSQL to delegate authorization decisions to Keycloak using OAuth tokens, leveraging Keycloak Authorization Services for fine-grained, token-based access control."
 authors = "The CloudNativePG Contributors"
 url = "https://github.com/cloudnative-pg/"
 documentation = "https://cloudnative-pg.io/"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,4 +18,5 @@ RUN meson setup build && meson compile -C build/
 
 FROM scratch
 
+COPY --from=builder /srv/LICENSE ./
 COPY --from=builder /srv/build/kc_validator.so /lib

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
-# syntax=docker/dockerfile:1.7
-FROM postgres:18 AS builder
+ARG BASE=ghcr.io/cloudnative-pg/postgresql:18-standard-trixie
+
+FROM $BASE AS builder
 ARG DEBIAN_FRONTEND=noninteractive
+USER root
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     set -eux; \
     apt-get update; \
@@ -8,22 +10,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     build-essential \
     meson \
     libcurl4-openssl-dev \
-    postgresql-server-dev-18; \
-WORKDIR /work
-COPY . .
-RUN meson setup build && meson build -C build/
+    postgresql-server-dev-18
+WORKDIR /srv
+COPY meson.build LICENSE ./
+COPY src/ ./src/
+RUN meson setup build && meson compile -C build/
 
-FROM ghcr.io/cloudnative-pg/postgresql:18-standard-trixie
-ARG DEBIAN_FRONTEND=noninteractive
-USER root
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends libcurl4 ca-certificates; \
-    apt-get clean; \
-    rm -rf /var/lib/apt/lists/*
-COPY --chmod=0644 docker/certs/server.crt /usr/local/share/ca-certificates/kc-root.crt
-RUN update-ca-certificates
-ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-USER postgres
-COPY --from=builder /work/build/kc_validator.so /usr/lib/postgresql/18/lib/
+FROM scratch
+
+COPY --from=builder /srv/build/kc_validator.so /share/extension/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,29 +1,42 @@
-ARG BASE=ghcr.io/cloudnative-pg/postgresql:18-standard-trixie
+ARG BASE=ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
 
 FROM $BASE AS builder
 ARG DEBIAN_FRONTEND=noninteractive
+ARG PG_MAJOR=18
+
 USER root
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    set -eux; \
-    apt-get update; \
+    # Base image system libraries
+    ldconfig -p | awk '{print $NF}' | grep '^/' | sort | uniq > /tmp/base-image-libs.out && \
+    # Build Dependencies
+    apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential \
-    meson \
-    libcurl4-openssl-dev \
-    postgresql-server-dev-18
+      build-essential \
+      meson \
+      libcurl4-openssl-dev \
+      "postgresql-server-dev-${PG_MAJOR}"
+
 WORKDIR /srv
 COPY meson.build LICENSE ./
 COPY src/ ./src/
 RUN meson setup build && meson compile -C build/
 
+# Gather keycloack-oauth-validator system libraries and their licenses
+RUN mkdir -p /system /licenses && \
+    ldd /srv/build/kc_validator.so | awk '{print $3}' | grep '^/' | sort | uniq > /tmp/all-deps.out && \
+    comm -13 /tmp/base-image-libs.out /tmp/all-deps.out > /tmp/libraries.out && \
+    for lib in $(cat /tmp/libraries.out); do cp -a "${lib%.so*}.so"* /system; done && \
+    # Licenses
+    for lib in $(find /system -maxdepth 1 -type f -name '*.so*'); do \
+      pkg=$(dpkg -S "$(basename "$lib")" | awk -F: '{print $1}'); \
+      [ -z "$pkg" ] && continue; \
+      mkdir -p "/licenses/$pkg" && cp -a /usr/share/doc/"$pkg"/* "/licenses/$pkg/"; \
+    done
+
+
 FROM scratch
 
 COPY --from=builder /srv/LICENSE ./
 COPY --from=builder /srv/build/kc_validator.so /lib/
-COPY --from=builder /usr/lib/*linux-gnu/libcurl* /system/
-COPY --from=builder /usr/lib/*linux-gnu/libnghttp3* /system/
-COPY --from=builder /usr/lib/*linux-gnu/libnghttp2* /system/
-COPY --from=builder /usr/lib/*linux-gnu/librtmp* /system/
-COPY --from=builder /usr/lib/*linux-gnu/libssh2* /system/
-COPY --from=builder /usr/lib/*linux-gnu/libpsl* /system/
-COPY --from=builder /usr/lib/*linux-gnu/libbrot* /system/
+COPY --from=builder /system /system/
+COPY --from=builder /licenses /licenses/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,4 +18,4 @@ RUN meson setup build && meson compile -C build/
 
 FROM scratch
 
-COPY --from=builder /srv/build/kc_validator.so /share/extension/
+COPY --from=builder /srv/build/kc_validator.so /lib

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,4 +19,4 @@ RUN meson setup build && meson compile -C build/
 FROM scratch
 
 COPY --from=builder /srv/LICENSE ./
-COPY --from=builder /srv/build/kc_validator.so /lib
+COPY --from=builder /srv/build/kc_validator.so /lib/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,3 +20,10 @@ FROM scratch
 
 COPY --from=builder /srv/LICENSE ./
 COPY --from=builder /srv/build/kc_validator.so /lib/
+COPY --from=builder /usr/lib/*linux-gnu/libcurl* /system/
+COPY --from=builder /usr/lib/*linux-gnu/libnghttp3* /system/
+COPY --from=builder /usr/lib/*linux-gnu/libnghttp2* /system/
+COPY --from=builder /usr/lib/*linux-gnu/librtmp* /system/
+COPY --from=builder /usr/lib/*linux-gnu/libssh2* /system/
+COPY --from=builder /usr/lib/*linux-gnu/libpsl* /system/
+COPY --from=builder /usr/lib/*linux-gnu/libbrot* /system/

--- a/examples/cnpg/cluster.yaml
+++ b/examples/cnpg/cluster.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 metadata:
   name: pg-oauth
 spec:
-  imageName: pg18-kc-validator:18.0
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
   instances: 1
 
   # Bootstrap from scratch and run our init SQL from a ConfigMap
@@ -19,9 +19,14 @@ spec:
   storage:
     size: 1Gi
   postgresql:
+    extensions:
+      - name: keycloak-oauth-validator
+        ld_library_path:
+          - system
+        image:
+          reference: ghcr.io/cloudnative-pg/postgres-keycloak-oauth-validator-testing:18-dev-trixie
     parameters:
       oauth_validator_libraries: "kc_validator"
-
       kc.token_endpoint: "https://<keycloak>/realms/<realm>/protocol/openid-connect/token"
       kc.audience:       "postgres-resource"
       kc.resource_name:  "appdb"


### PR DESCRIPTION
Some improvements were made to the Dockerfile to build using meson and use a scratch image to have an extension image compatible with CloudNativePG

Closes #10